### PR TITLE
Add BDUK task browser sample app

### DIFF
--- a/bduk_app/README.md
+++ b/bduk_app/README.md
@@ -1,0 +1,13 @@
+# BDUK Task Browser
+
+This simple command-line application lets Building Digital UK (BDUK) staff browse candidate tasks and view research findings associated with each task.
+
+## Usage
+
+Run the script using Python:
+
+```bash
+python bduk_app/browse_tasks.py
+```
+
+The application will display a numbered list of tasks. Enter the corresponding number to see the related research finding. Enter `0` to exit.

--- a/bduk_app/bduk_tasks.csv
+++ b/bduk_app/bduk_tasks.csv
@@ -1,0 +1,4 @@
+id,task,research_finding
+1,Review broadband policy compliance,"Staff reported difficulties tracking policy updates. Research suggests using automated compliance monitoring tools."
+2,Coordinate fibre rollout with local councils,"Stakeholder interviews indicated improved outcomes when dedicated communication channels were established."
+3,Maintain project documentation,"Research found teams benefited from standardized templates and regular audits to ensure documentation completeness."

--- a/bduk_app/browse_tasks.py
+++ b/bduk_app/browse_tasks.py
@@ -1,0 +1,43 @@
+import csv
+
+DATA_FILE = 'bduk_app/bduk_tasks.csv'
+
+def load_tasks():
+    with open(DATA_FILE, newline='') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+def display_tasks(tasks):
+    print("Available tasks:\n")
+    for idx, task in enumerate(tasks, 1):
+        print(f"{idx}. {task['task']}")
+
+
+def get_selection(num_tasks):
+    while True:
+        try:
+            choice = int(input("\nEnter task number to view research findings (0 to exit): "))
+            if 0 <= choice <= num_tasks:
+                return choice
+            print("Invalid selection. Try again.")
+        except ValueError:
+            print("Please enter a valid number.")
+
+
+def main():
+    tasks = load_tasks()
+    if not tasks:
+        print("No tasks available.")
+        return
+    while True:
+        display_tasks(tasks)
+        choice = get_selection(len(tasks))
+        if choice == 0:
+            print("Goodbye!")
+            break
+        task = tasks[choice - 1]
+        print(f"\nResearch findings for '{task['task']}':\n{task['research_finding']}\n")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add simple CSV sample of BDUK tasks with research findings
- add a Python CLI to browse tasks and show findings
- document how to run the CLI

## Testing
- `pytest -q`
- `python bduk_app/browse_tasks.py <<'EOF'
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68873b2e8bb0832c91b82fc7db9de6d7