### PR TITLE
Add GUI task browser for BDUK

### DIFF
--- a/bduk_app/README.md
+++ b/bduk_app/README.md
@@ -1,8 +1,8 @@
 # BDUK Task Browser
 
-This simple command-line application lets Building Digital UK (BDUK) staff browse candidate tasks and view research findings associated with each task.
+This directory contains small applications to help Building Digital UK (BDUK) staff browse candidate tasks and view associated research findings.
 
-## Usage
+## Command Line Browser
 
 Run the script using Python:
 
@@ -11,3 +11,15 @@ python bduk_app/browse_tasks.py
 ```
 
 The application will display a numbered list of tasks. Enter the corresponding number to see the related research finding. Enter `0` to exit.
+
+## Graphical Browser
+
+A simple Tkinter-based GUI is available in `gui_tasks.py`. It loads the same BDUK task file and optionally retrieves the full WORKBank dataset from Hugging Face using the `datasets` library.
+
+Run the GUI with:
+
+```bash
+python bduk_app/gui_tasks.py
+```
+
+Use the *Load Full Dataset* button to attempt downloading the full dataset as described in the repository README. If the environment lacks internet access or the `datasets` package, an error message will be shown.

--- a/bduk_app/gui_tasks.py
+++ b/bduk_app/gui_tasks.py
@@ -1,0 +1,84 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+import csv
+
+DATA_FILE = 'bduk_app/bduk_tasks.csv'
+
+
+def load_bduk_tasks():
+    """Load task list for BDUK staff."""
+    with open(DATA_FILE, newline='') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def load_full_dataset():
+    """Retrieve full WORKBank dataset from Hugging Face if available."""
+    try:
+        from datasets import load_dataset
+        ds = load_dataset(
+            "SALT-NLP/WORKBank",
+            data_files="task_data/task_statement_with_metadata.csv",
+            split="train",
+        )
+        return ds
+    except Exception as exc:
+        messagebox.showerror("Dataset Error", f"Could not load dataset: {exc}")
+        return None
+
+
+class TaskBrowser(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("BDUK Task Browser")
+        self.geometry("700x400")
+        self.tasks = load_bduk_tasks()
+        self.dataset = None
+        self.create_widgets()
+
+    def create_widgets(self):
+        frame = ttk.Frame(self)
+        frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        self.task_list = tk.Listbox(frame)
+        for task in self.tasks:
+            self.task_list.insert(tk.END, task['task'])
+        self.task_list.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.task_list.bind("<<ListboxSelect>>", self.display_task_info)
+
+        scrollbar = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=self.task_list.yview)
+        scrollbar.pack(side=tk.LEFT, fill=tk.Y)
+        self.task_list.config(yscrollcommand=scrollbar.set)
+
+        self.info_text = tk.Text(frame, wrap=tk.WORD)
+        self.info_text.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
+
+        load_button = ttk.Button(self, text="Load Full Dataset", command=self.load_dataset)
+        load_button.pack(pady=5)
+
+    def display_task_info(self, event):
+        sel = self.task_list.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        task = self.tasks[idx]
+        self.info_text.delete("1.0", tk.END)
+        self.info_text.insert(tk.END, f"Task: {task['task']}\n\n")
+        self.info_text.insert(tk.END, f"Research Finding:\n{task['research_finding']}")
+
+    def load_dataset(self):
+        if self.dataset is None:
+            self.dataset = load_full_dataset()
+            if self.dataset is None:
+                return
+        messagebox.showinfo("Dataset", f"Loaded {len(self.dataset)} tasks from WORKBank")
+
+
+def main():
+    app = TaskBrowser()
+    app.mainloop()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `gui_tasks.py` with a Tkinter interface that can optionally download the WORKBank dataset
- document the GUI in `bduk_app/README.md`

## Testing
- `python -m py_compile bduk_app/gui_tasks.py bduk_app/browse_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68876228b7dc832cb5d621047a5aa47d